### PR TITLE
Install versions of dependencies known to be compatible

### DIFF
--- a/action.js
+++ b/action.js
@@ -1,6 +1,6 @@
 require('child_process')
   .execSync(
-    'npm install @actions/core @actions/github',
+    'npm install @actions/core@1.2.4 @actions/github@2.2.0',
     { cwd: __dirname }
   );
 const fs = require('fs');


### PR DESCRIPTION
It seems a recent update to actions/github broke this action. This just specifies to use an older version and specifies to use the current latest actions/core in case of breaking changes in that dependency.